### PR TITLE
Update example.py and benchmark.py for Python 3

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,24 +1,20 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+"""Benchmark script for FFX encryption/decryption performance."""
 
-from __future__ import absolute_import
-from __future__ import print_function
-import time
-import random
-import string
 import argparse
+import random
+import time
 
-import ffx
+import ffx 
 from ffx import FFXInteger
-from six.moves import range
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--radix", type=int, default=2)
-    parser.add_argument("--tweaksize", type=int, default=8)
-    parser.add_argument("--messagesize", type=int, default=32)
-    parser.add_argument("--trials", type=int, default=10, required=False)
+    parser = argparse.ArgumentParser(description="Benchmark FFX encryption/decryption")
+    parser.add_argument("--radix", type=int, default=2, help="Radix for FFX (2-36)")
+    parser.add_argument("--tweaksize", type=int, default=8, help="Size of tweak in radix digits")
+    parser.add_argument("--messagesize", type=int, default=32, help="Size of message in radix digits")
+    parser.add_argument("--trials", type=int, default=10, help="Number of trials to run")
     args = parser.parse_args()
 
     radix = args.radix
@@ -26,49 +22,52 @@ def main():
     messagesize = args.messagesize
     trials = args.trials
 
+    # Generate random key
     keysize = 128
     K = random.randint(0, 2 ** keysize - 1)
     K = FFXInteger(K, radix=2, blocksize=keysize)
 
-    print(
-        'RADIX={}, TWEAKSIZE={}, MESSAGESIZE={}, KEY={:x}'.format(
-            radix,
-            tweaksize,
-            messagesize,
-            K.to_int()
-        )
-    )
+    banner = [
+        f'RADIX={radix}',
+        f'TWEAKSIZE={tweaksize}',
+        f'MESSAGESIZE={messagesize}',
+        f'KEY=0x{K.to_int():x}'
+              ]
+    print(', '.join(banner))
 
     ffx_obj = ffx.new(K.to_bytes(), radix)
+    
     for i in range(1, trials):
+        # Generate random tweak
         T = random.randint(0, radix ** tweaksize - 1)
         T = FFXInteger(T, radix=radix, blocksize=tweaksize)
 
+        # Generate random message
         M1 = random.randint(0, radix ** messagesize - 1)
-        M1 = FFXInteger(M1, radix=radix, blocksize=messagesize)
+        M1 = FFXInteger(M1, radix=radix, blocksize=messagesize) 
 
-        start = time.time()
+        # Benchmark encryption
+        start = time.perf_counter()
         C = ffx_obj.encrypt(T, M1)
-        encrypt_cost = time.time() - start
-        encrypt_cost *= 1000.0
+        encrypt_cost = (time.perf_counter() - start) * 1000.0
 
-        start = time.time()
+        # Benchmark decryption
+        start = time.perf_counter()
         M2 = ffx_obj.decrypt(T, C)
-        decrypt_cost = time.time() - start
-        decrypt_cost *= 1000.0
+        decrypt_cost = (time.perf_counter() - start) * 1000.0
 
-        assert M1 == M2
+        # Verify correctness
+        assert M1 == M2, f"Decryption failed: {M1} != {M2}"
 
-        print(
-            'test #{} SUCCESS: (encrypt_cost={} ms, decrypt_cost={} ms, tweak={}, plaintext={}, ciphertext={})'.format(
-                i,
-                round(encrypt_cost, 1),
-                round(decrypt_cost, 1),
-                T,
-                M1,
-                C,
-            )
-        )
+        trial_num = str(i).zfill(len(str(trials - 1)))
+        results = [
+            f'encrypt_cost={encrypt_cost:.1f}ms',
+            f'decrypt_cost={decrypt_cost:.1f}ms',
+            f'tweak={T}',
+            f'plaintext={M1}',
+            f'ciphertext={C}',
+                    ]
+        print(f'test #{trial_num} SUCCESS: ({", ".join(results)})')
 
 
 if __name__ == "__main__":

--- a/example.py
+++ b/example.py
@@ -1,23 +1,31 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+"""Example usage of the FFX library."""
 
-from __future__ import absolute_import
-from __future__ import print_function
 import ffx
 
 
+def main():
+    # Set up parameters
 radix = 2
-blocksize = 2 ** 10
+    blocksize = 2 ** 10  # 1024 bits
 
+    # Create key, tweak, and message
 K = ffx.FFXInteger('0' * 128, radix=radix, blocksize=128)
 T = ffx.FFXInteger('0' * blocksize, radix=radix, blocksize=blocksize)
 X = ffx.FFXInteger('0' * blocksize, radix=radix, blocksize=blocksize)
 
+    # Create FFX encrypter
 ffx_obj = ffx.new(K.to_bytes(16), radix=radix)
 
+    # Encrypt and decrypt
 C = ffx_obj.encrypt(T, X)
 Y = ffx_obj.decrypt(T, C)
 
-print(X)
-print(C)
-print(Y)
+    print(f"Plaintext:  {X}")
+    print(f"Ciphertext: {C}")
+    print(f"Decrypted:  {Y}")
+    print(f"\nRoundtrip successful: {X == Y}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Use print() functions instead of print statements
- Use f-strings for formatting
- Use time.perf_counter() for accurate timing
- Use str.zfill() instead of deprecated string.rjust()
- Add shebang for Python 3