### PR TITLE
Rewrite benchmark.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,27 @@ Test vectors from the official NIST submission: [aes-ffx-vectors.txt](http://csr
 
 ## Benchmarks
 
+Run the default sweep across representative radices and message sizes:
+
+```bash
+python benchmark.py
+```
+
+Or time a single configuration:
+
 ```bash
 python benchmark.py --radix 10 --tweaksize 10 --messagesize 16
 ```
 
-Example output:
+Each configuration is warmed up, then every op is timed individually and
+validated with an encrypt/decrypt round-trip. Example output:
 
 ```
-RADIX=10, TWEAKSIZE=10, MESSAGESIZE=16, KEY=0x7fab9cfe5f0b2f4b61fc18fc018e1d66
-test #1 SUCCESS: (encrypt_cost=0.5ms, decrypt_cost=0.1ms, tweak=4116892577, plaintext=2673647323700035, ciphertext=0238930243347266)
-test #2 SUCCESS: (encrypt_cost=0.1ms, decrypt_cost=0.1ms, tweak=4681498724, plaintext=6915018802668851, ciphertext=4790098135418225)
-...
+KEY=0x...  iterations=5000  warmup=200
+----------------------------------------------------------------------------
+decimal SSN              r=10 t=10  n=9   | enc   46.9us (...)   20,851/s | dec   46.9us   20,838/s
+decimal credit card      r=10 t=10  n=16  | enc   46.7us (...)   20,879/s | dec   46.7us   20,919/s
+base36, 16-char          r=36 t=16  n=16  | enc   63.6us (...)   15,332/s | dec   63.2us   15,410/s
 ```
 
 ## Project Structure

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,73 +1,140 @@
 #!/usr/bin/env python3
-"""Benchmark script for FFX encryption/decryption performance."""
+"""Benchmark script for FFX encryption/decryption performance.
+
+Two modes:
+
+* Sweep (default): time a set of representative (radix, message size)
+  configurations and print a comparison table.
+
+      python benchmark.py
+
+* Single config: pass --radix / --messagesize / --tweaksize to time one
+  configuration in detail.
+
+      python benchmark.py --radix 10 --tweaksize 10 --messagesize 16
+
+Each configuration is warmed up before timing (the first call to a given
+message/tweak length builds a small parameter cache), then every op is timed
+individually so we can report the median, min, and p95 latency alongside
+throughput. All results are validated with an encrypt/decrypt round-trip.
+"""
 
 import argparse
 import random
+import statistics
 import time
 
-import ffx 
+import ffx
 from ffx import FFXInteger
+
+
+# (radix, tweak size, message size, label) used by the default sweep.
+SWEEP_CONFIGS = [
+    (2, 8, 32, "binary, 32-bit"),
+    (10, 0, 9, "decimal SSN (no tweak)"),
+    (10, 10, 9, "decimal SSN"),
+    (10, 10, 16, "decimal credit card"),
+    (16, 8, 16, "hex, 16-digit"),
+    (36, 16, 16, "base36, 16-char"),
+    (10, 10, 64, "decimal, 64-digit"),
+]
+
+
+def _random_ffx(radix, size):
+    """Random FFXInteger with `size` digits in the given radix."""
+    value = random.randint(0, radix ** size - 1)
+    return FFXInteger(value, radix=radix, blocksize=size)
+
+
+def time_config(ffx_obj, radix, tweaksize, messagesize, iterations, warmup):
+    """Time one configuration.
+
+    Returns a dict with encrypt/decrypt latency stats (microseconds) and
+    throughput (ops/sec). Raises AssertionError if any round-trip fails.
+    """
+    # Pre-generate inputs so timing excludes RNG / object construction.
+    samples = []
+    for _ in range(iterations):
+        if tweaksize > 0:
+            tweak = _random_ffx(radix, tweaksize)
+        else:
+            tweak = 0
+        samples.append((tweak, _random_ffx(radix, messagesize)))
+
+    # Warmup: build the per-length parameter cache and prime the interpreter.
+    for tweak, msg in samples[: max(1, min(warmup, len(samples)))]:
+        ffx_obj.decrypt(tweak, ffx_obj.encrypt(tweak, msg))
+
+    enc_times, dec_times = [], []
+    enc_total = dec_total = 0.0
+    for tweak, msg in samples:
+        start = time.perf_counter()
+        cipher = ffx_obj.encrypt(tweak, msg)
+        dt = time.perf_counter() - start
+        enc_times.append(dt * 1e6)
+        enc_total += dt
+
+        start = time.perf_counter()
+        plain = ffx_obj.decrypt(tweak, cipher)
+        dt = time.perf_counter() - start
+        dec_times.append(dt * 1e6)
+        dec_total += dt
+
+        assert plain == msg, f"round-trip failed: {msg} != {plain}"
+
+    def stats(times, total):
+        ordered = sorted(times)
+        p95 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))]
+        return {
+            "median_us": statistics.median(times),
+            "min_us": ordered[0],
+            "p95_us": p95,
+            "ops_per_sec": len(times) / total if total else float("inf"),
+        }
+
+    return {"encrypt": stats(enc_times, enc_total), "decrypt": stats(dec_times, dec_total)}
+
+
+def _print_row(label, radix, tweaksize, messagesize, result):
+    e, d = result["encrypt"], result["decrypt"]
+    print(
+        f"{label:24s} r={radix:<2d} t={tweaksize:<3d} n={messagesize:<3d} | "
+        f"enc {e['median_us']:6.1f}us (min {e['min_us']:5.1f}, p95 {e['p95_us']:6.1f}) "
+        f"{e['ops_per_sec']:8,.0f}/s | "
+        f"dec {d['median_us']:6.1f}us {d['ops_per_sec']:8,.0f}/s"
+    )
 
 
 def main():
     parser = argparse.ArgumentParser(description="Benchmark FFX encryption/decryption")
-    parser.add_argument("--radix", type=int, default=2, help="Radix for FFX (2-36)")
-    parser.add_argument("--tweaksize", type=int, default=8, help="Size of tweak in radix digits")
-    parser.add_argument("--messagesize", type=int, default=32, help="Size of message in radix digits")
-    parser.add_argument("--trials", type=int, default=10, help="Number of trials to run")
+    parser.add_argument("--radix", type=int, help="Radix for FFX (2-36); single-config mode")
+    parser.add_argument("--tweaksize", type=int, default=8, help="Tweak size in radix digits")
+    parser.add_argument("--messagesize", type=int, help="Message size in radix digits; single-config mode")
+    parser.add_argument("--iterations", type=int, default=5000, help="Timed iterations per config")
+    parser.add_argument("--warmup", type=int, default=200, help="Warmup iterations per config")
+    parser.add_argument("--seed", type=int, default=None, help="RNG seed for reproducibility")
     args = parser.parse_args()
 
-    radix = args.radix
-    tweaksize = args.tweaksize
-    messagesize = args.messagesize
-    trials = args.trials
+    if args.seed is not None:
+        random.seed(args.seed)
 
-    # Generate random key
-    keysize = 128
-    K = random.randint(0, 2 ** keysize - 1)
-    K = FFXInteger(K, radix=2, blocksize=keysize)
+    # Random 128-bit key.
+    key = FFXInteger(random.randint(0, 2 ** 128 - 1), radix=2, blocksize=128)
+    print(f"KEY=0x{key.to_int():032x}  iterations={args.iterations}  warmup={args.warmup}")
+    print("-" * 100)
 
-    banner = [
-        f'RADIX={radix}',
-        f'TWEAKSIZE={tweaksize}',
-        f'MESSAGESIZE={messagesize}',
-        f'KEY=0x{K.to_int():x}'
-              ]
-    print(', '.join(banner))
+    single = args.radix is not None or args.messagesize is not None
+    if single:
+        radix = args.radix if args.radix is not None else 10
+        messagesize = args.messagesize if args.messagesize is not None else 16
+        configs = [(radix, args.tweaksize, messagesize, f"radix{radix}")]
+    else:
+        configs = SWEEP_CONFIGS
 
-    ffx_obj = ffx.new(K.to_bytes(), radix)
-    
-    for i in range(1, trials):
-        # Generate random tweak
-        T = random.randint(0, radix ** tweaksize - 1)
-        T = FFXInteger(T, radix=radix, blocksize=tweaksize)
-
-        # Generate random message
-        M1 = random.randint(0, radix ** messagesize - 1)
-        M1 = FFXInteger(M1, radix=radix, blocksize=messagesize) 
-
-        # Benchmark encryption
-        start = time.perf_counter()
-        C = ffx_obj.encrypt(T, M1)
-        encrypt_cost = (time.perf_counter() - start) * 1000.0
-
-        # Benchmark decryption
-        start = time.perf_counter()
-        M2 = ffx_obj.decrypt(T, C)
-        decrypt_cost = (time.perf_counter() - start) * 1000.0
-
-        # Verify correctness
-        assert M1 == M2, f"Decryption failed: {M1} != {M2}"
-
-        trial_num = str(i).zfill(len(str(trials - 1)))
-        results = [
-            f'encrypt_cost={encrypt_cost:.1f}ms',
-            f'decrypt_cost={decrypt_cost:.1f}ms',
-            f'tweak={T}',
-            f'plaintext={M1}',
-            f'ciphertext={C}',
-                    ]
-        print(f'test #{trial_num} SUCCESS: ({", ".join(results)})')
+    for radix, tweaksize, messagesize, label in configs:
+        ffx_obj = ffx.new(key.to_bytes(16), radix)
+        result = time_config(ffx_obj, radix, tweaksize, messagesize, args.iterations, args.warmup)
+        _print_row(label, radix, tweaksize, messagesize, result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The old `benchmark.py` was unusable for performance comparison:

- **`%.1f` millisecond precision** — every op printed as `0.1ms`.
- **`range(1, trials)`** — off-by-one; ran `trials-1` iterations and skipped index 0.
- **No warmup** — the first timed op absorbed one-time cache-building cost.
- Single-op timing only; no throughput, no distribution, no cross-radix/size coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)