### PR TITLE
Fix stale P cache when reusing an encrypter across tweak lengths

### DIFF
--- a/ffx/encrypter.py
+++ b/ffx/encrypter.py
@@ -59,7 +59,7 @@ class FFXEncrypter:
         
         self._key = key
         self._ecb = AES.new(key, AES.MODE_ECB)
-        self._P_cache: dict[int, bytes] = {}
+        self._P_cache: dict[tuple[int, int], bytes] = {}
 
     @staticmethod
     def _is_even(n: int) -> bool:
@@ -109,8 +109,13 @@ class FFXEncrypter:
         else:
             m = int(math.ceil(n / 2.0))
 
-        # Build P (cached per message length)
-        if n not in self._P_cache:
+        # Build P (cached per (message length, tweak length)). P encodes both
+        # n and the tweak length t (in characters), so the cache must be keyed
+        # by both; keying by n alone returns a stale P when the same encrypter
+        # is reused across tweaks of different lengths for the same message
+        # length.
+        cache_key = (n, t)
+        if cache_key not in self._P_cache:
             P = b'\x01'  # vers
             P += b'\x02'  # method
             P += b'\x01'  # addition
@@ -119,27 +124,28 @@ class FFXEncrypter:
             P += long_to_bytes(self._split(n) % 256, 1)
             P += long_to_bytes(n, 4)
             P += long_to_bytes(t, 4)
-            self._P_cache[n] = P
+            self._P_cache[cache_key] = P
+        P = self._P_cache[cache_key]
 
         # Build Q
         if tweak == 0:
             Q = b''
         else:
             Q = str(tweak).encode('latin-1')
-        
+
         Q += b'\x00' * (((-1 * t) - b_bytes - 1) % 16)
         Q += long_to_bytes(i, blocksize=1)
-        
+
         b_as_bytes = long_to_bytes(b)
         Q += b'\x00' * (b_bytes - len(b_as_bytes))
         Q += b_as_bytes[-b_bytes:] if b_bytes > 0 else b''
 
         cbc = AES.new(self._key, AES.MODE_CBC, b'\x00' * 16)
 
-        assert len(self._P_cache[n]) % 16 == 0
+        assert len(P) % 16 == 0
         assert len(Q) % 16 == 0
 
-        Y = cbc.encrypt(self._P_cache[n] + Q)[-16:]
+        Y = cbc.encrypt(P + Q)[-16:]
 
         # Extend Y if needed
         j = 1

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -144,6 +144,75 @@ class TestLongMessages:
         assert decrypted == plain
 
 
+class TestTweakLengthCacheKey:
+    """Reusing one encrypter across tweaks of different lengths.
+
+    The precomputed block P encodes both the message length n and the tweak
+    length t. The parameter cache must therefore be keyed by (n, t): keying by
+    n alone returns a stale P for the same n once a different tweak length has
+    been seen, corrupting every subsequent result for that length.
+
+    A freshly constructed encrypter never has a poisoned cache, so it is the
+    correct reference: a reused encrypter must produce identical output.
+    """
+
+    def _fresh(self, standard_key):
+        return ffx.new(standard_key.to_bytes(16), radix=10)
+
+    def test_long_tweak_then_short_tweak(self, standard_key):
+        """A short-tweak result must not depend on an earlier long-tweak call."""
+        msg = FFXInteger('0123456789', radix=10, blocksize=10)
+        long_tweak = FFXInteger('9876543210', radix=10, blocksize=10)   # t=10
+        short_tweak = FFXInteger('1234', radix=10, blocksize=4)         # t=4
+
+        reference = self._fresh(standard_key).encrypt(short_tweak, msg)
+
+        reused = self._fresh(standard_key)
+        reused.encrypt(long_tweak, msg)          # primes cache for n=10 with t=10
+        result = reused.encrypt(short_tweak, msg)  # must still use t=4
+
+        assert result == reference
+
+    def test_short_tweak_then_long_tweak(self, standard_key):
+        """And the reverse ordering."""
+        msg = FFXInteger('0123456789', radix=10, blocksize=10)
+        long_tweak = FFXInteger('9876543210', radix=10, blocksize=10)
+        short_tweak = FFXInteger('1234', radix=10, blocksize=4)
+
+        reference = self._fresh(standard_key).encrypt(long_tweak, msg)
+
+        reused = self._fresh(standard_key)
+        reused.encrypt(short_tweak, msg)
+        result = reused.encrypt(long_tweak, msg)
+
+        assert result == reference
+
+    def test_tweaked_then_untweaked(self, standard_key):
+        """No-tweak (t=0) after a tweaked call for the same message length."""
+        msg = FFXInteger('0123456789', radix=10, blocksize=10)
+        tweak = FFXInteger('9876543210', radix=10, blocksize=10)
+
+        reference = self._fresh(standard_key).encrypt(0, msg)
+
+        reused = self._fresh(standard_key)
+        reused.encrypt(tweak, msg)
+        result = reused.encrypt(0, msg)
+
+        assert result == reference
+
+    def test_reused_roundtrip_across_tweak_lengths(self, standard_key):
+        """Encrypt/decrypt still round-trips when tweak lengths are interleaved."""
+        obj = self._fresh(standard_key)
+        msg = FFXInteger('0123456789', radix=10, blocksize=10)
+        for tweak in [
+            FFXInteger('9876543210', radix=10, blocksize=10),
+            FFXInteger('1234', radix=10, blocksize=4),
+            0,
+            FFXInteger('55', radix=10, blocksize=2),
+        ]:
+            assert obj.decrypt(tweak, obj.encrypt(tweak, msg)) == msg
+
+
 class TestMinimumMessageSize:
     """Tests for minimum message sizes."""
 


### PR DESCRIPTION
## The bug

The round-function block `P` encodes **both** the message length `n` and the tweak length `t`:

```python
P += long_to_bytes(n, 4)
P += long_to_bytes(t, 4)
```

…but the cache was keyed by `n` alone (`self._P_cache[n]`). Reusing one `FFXEncrypter` to encrypt messages of the same length under tweaks of **different lengths** returns a stale `P` (carrying the *first* tweak length seen) for every call after the first — producing **incorrect ciphertext**.

The existing 128 tests never caught it because each test constructs a fresh encrypter, so the cache is never poisoned.

## The fix

Key the cache by `(n, t)`.

## Regression tests

Added `TestTweakLengthCacheKey`, which reuses one encrypter across long/short/no tweaks and compares against a **freshly constructed** encrypter (the correct reference). Three of the four new tests fail against the previous `n`-only cache and pass with the fix. Full suite: **132 passed**.

## Scope

- Minimal, output-preserving for every single-tweak-length usage (all official NIST vectors unchanged).
- Independent of the benchmark PR (#26). The performance PR is stacked on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)