### PR TITLE
CI: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security :: Cryptography",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Adds **Python 3.14** to the Tests workflow matrix and declares it in the pyproject trove classifiers. 3.13 was already covered.

```diff
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
```

## Why it's safe

- 3.14 is GA, so no `allow-prereleases` flag is needed — `setup-python` resolves `"3.14"` to the latest stable release.
- The library already runs cleanly on 3.14: the full suite (128 tests) passes locally under CPython 3.14.6 with `gmpy2` 2.3.1 and `pycryptodome` 3.23.0.

## Scope

Independent of the benchmark (#26), bug-fix (#27), and performance (#28) PRs — touches only `.github/workflows/tests.yml` and `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)