### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/ffx/__init__.py
+++ b/ffx/__init__.py
@@ -44,7 +44,7 @@ __all__ = [
     'bytes_to_long',
 ]
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 
 def new(key: bytes, radix: int) -> FFXEncrypter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libffx"
-version = "1.0.2"
+version = "1.0.3"
 description = "FFX - Format Preserving Encryption (NIST FFX-A2 mode of operation)"
 readme = "README_PYPI.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bumps the package version to `1.0.3` in `pyproject.toml` and `ffx/__init__.py` ahead of the next release.

Changes included in this release (since v1.0.2):
- Fix stale P cache when reusing an encrypter across tweak lengths (correctness fix)
- Optimize FFX round function (~5x faster on typical formats)
- Add Python 3.14 to the CI test matrix
- Rewrite benchmark.py (warmup, throughput, distribution stats, sweep)

Publishing to PyPI is handled automatically by the `publish.yml` workflow (trusted publishing) once the GitHub release for `v1.0.3` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)