### PR TITLE
Security hardening: CodeQL, Dependabot, SECURITY.md, pinned Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Python dependencies (pyproject.toml + requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions used in workflows (keeps pinned SHAs current)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       
@@ -26,7 +26,7 @@ jobs:
         run: python -m build
       
       - name: Store distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -42,10 +42,10 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - name: Download distribution packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-package-distributions
           path: dist/
       
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,10 +18,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+`libffx` is distributed on [PyPI](https://pypi.org/project/libffx/). Security
+fixes are released against the latest published version — please make sure you
+are on the most recent release before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report them privately through GitHub's
+[private vulnerability reporting](https://github.com/kpdyer/libffx/security/advisories/new):
+
+1. Go to the **Security** tab of this repository.
+2. Click **Report a vulnerability**.
+3. Include a description, the affected version(s), and reproduction steps.
+
+You can expect an initial response within a few days. Once an issue is
+confirmed, a fix and a coordinated disclosure timeline will be arranged.
+
+## Scope
+
+`libffx` implements format-preserving encryption (NIST FFX-A2). Reports that are
+especially relevant include:
+
+- Cryptographic correctness or weaknesses in the FFX implementation
+- Timing side channels in encryption / decryption
+- Memory-safety or input-validation issues reachable from the public API
+
+Note that FFX/FPE has inherent, documented limitations (for example, small
+domains leak information). Reports that restate these known properties of the
+algorithm are considered out of scope.


### PR DESCRIPTION
Supply-chain hardening for the repo. Companion to the GitHub settings changes (branch protection, secret scanning + push protection, private vulnerability reporting) that were enabled separately.

## What's in this PR

- **CodeQL code scanning** (`.github/workflows/codeql.yml`) — Python analysis with `security-extended` queries, on push/PR to `master` and a weekly schedule. Results land in the Security tab (not a required merge check).
- **Dependabot version updates** (`.github/dependabot.yml`) — weekly updates for `pip` deps and `github-actions` (grouped), which keeps the pinned SHAs below current.
- **`SECURITY.md`** — security policy directing reporters to GitHub private vulnerability reporting; notes crypto-specific scope.
- **Pinned Actions** — every `uses:` in `tests.yml` and `publish.yml` pinned to a full commit SHA with a `# vN` comment (defends against tag/branch hijack — matters since `publish.yml` pushes to PyPI).
- **Least privilege** — added `permissions: contents: read` to the Tests workflow.

## Notes
- `publish.yml` already used OIDC trusted publishing (no stored PyPI token) and a `contents: read` default — left intact.
- This PR is itself gated by the new branch protection, so it will merge once the `test (3.9…3.14)` checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)