### PR TITLE
Drop EOL Python 3.9, raise minimum to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FFX - Format Preserving Encryption
 
 [![Tests](https://github.com/kpdyer/libffx/actions/workflows/tests.yml/badge.svg)](https://github.com/kpdyer/libffx/actions/workflows/tests.yml)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Python implementation of the FFX Mode of Operation for Format-Preserving Encryption (FPE).

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -1,6 +1,6 @@
 # libffx - Format Preserving Encryption
 
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Python implementation of the FFX Mode of Operation for Format-Preserving Encryption (FPE).

--- a/ffx/__init__.py
+++ b/ffx/__init__.py
@@ -44,7 +44,7 @@ __all__ = [
     'bytes_to_long',
 ]
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 
 def new(key: bytes, radix: int) -> FFXEncrypter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libffx"
-version = "1.0.3"
+version = "1.1.0"
 description = "FFX - Format Preserving Encryption (NIST FFX-A2 mode of operation)"
 readme = "README_PYPI.md"
 license = {text = "MIT"}
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -29,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Security :: Cryptography",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "gmpy2>=2.1.0",
     "pycryptodome>=3.15.0",
@@ -57,7 +56,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

Python 3.9 reached end-of-life in October 2025. This drops it from the supported version matrix and raises the minimum to **3.10**. (Python 3.10 stays — it isn't EOL until October 2026.)

## Changes

- **pyproject.toml** — `requires-python` → `>=3.10`, removed the `3.9` classifier, `[tool.mypy] python_version` → `3.10`
- **.github/workflows/tests.yml** — CI test matrix now `3.10`–`3.14`
- **README.md / README_PYPI.md** — badges → `Python 3.10+`
- Version bump `1.0.3` → `1.1.0` (minor, not patch, since narrowing the supported Python range is a compatibility change even though the API is unchanged)

## Notes

- The source in `ffx/` had no 3.9 compat shims, so there's no dead code to remove. Adopting 3.10-only syntax (e.g. `X | Y` unions) is possible but deliberately left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)