### PR TITLE
Add PyPI version badge to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # FFX - Format Preserving Encryption
 
+[![PyPI version](https://img.shields.io/pypi/v/libffx.svg)](https://pypi.org/project/libffx/)
 [![Tests](https://github.com/kpdyer/libffx/actions/workflows/tests.yml/badge.svg)](https://github.com/kpdyer/libffx/actions/workflows/tests.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -1,5 +1,6 @@
 # libffx - Format Preserving Encryption
 
+[![PyPI version](https://img.shields.io/pypi/v/libffx.svg)](https://pypi.org/project/libffx/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Adds a PyPI version badge to both READMEs, linking to the package page. The badge auto-updates to show the latest published version of `libffx`.

- `README.md` — badge added above the Tests badge
- `README_PYPI.md` — badge added above the Python version badge (this is the readme published to PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)