### PR TITLE
Pre-release fixes for 2.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Run tests
         run: pytest -v
 
+      - name: Type-check
+        run: mypy ffx
+
       - name: Run example
         run: python example.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+include README_PYPI.md
+include SECURITY.md
+include aes-ffx-vectors.txt
+include example.py
+include benchmark.py
+recursive-include tests *.py
+recursive-include examples *.py

--- a/README.md
+++ b/README.md
@@ -50,13 +50,17 @@ x = plain.decrypt_int(y, domain=10**9)
 FF1(key, *, radix=None, alphabet=None, allow_small_domain=False)
 ```
 
-- `key`: exactly 16, 24, or 32 bytes (AES-128/192/256); else `KeyLengthError`.
+- `key`: `bytes` (or `bytearray`) of exactly 16, 24, or 32 bytes
+  (AES-128/192/256); other lengths raise `KeyLengthError`.
 - `radix`: 2-36; the alphabet is `"0123456789abcdefghijklmnopqrstuvwxyz"[:radix]`.
 - `alphabet`: explicit alphabet string (2-65536 unique Unicode characters).
   At most one of `radix`/`alphabet` may be given. With neither, only the
   integer API is available.
 - `allow_small_domain`: relax the minimum domain from 1,000,000 (Draft
   SP 800-38G Rev 1) to 100 (original SP 800-38G).
+
+Instances hold no per-call state and are safe to share between threads;
+construct one per key and reuse it.
 
 #### `encrypt` / `decrypt`
 
@@ -71,8 +75,9 @@ outside the alphabet raise `AlphabetError`. The message length `n` must
 satisfy `n >= 2` and `radix**n >= 1_000_000` (or `>= 100` with
 `allow_small_domain=True`); otherwise `DomainError`.
 
-Tweaks are arbitrary bytes (`len < 2**32`) acting as public associated data:
-the same plaintext under different tweaks yields unrelated ciphertexts.
+Tweaks are arbitrary bytes (`len < 2**32`, else `DomainError`) acting as
+public associated data: the same plaintext under different tweaks yields
+unrelated ciphertexts.
 
 #### `encrypt_int` / `decrypt_int`
 
@@ -82,10 +87,19 @@ decrypt_int(y, *, domain, tweak=b"") -> int
 ```
 
 Encrypt an integer `0 <= x < domain` to another integer in the same range.
+`domain` must be at least 1,000,000 (100 with `allow_small_domain=True`);
+a smaller domain or an out-of-range value raises `DomainError`.
 Internally this runs FF1 at radix 2 over `(domain - 1).bit_length()` bits and
 cycle-walks until the result lands inside the domain. Results depend only on
 (key, domain, tweak), not on the instance's `radix`/`alphabet`, so the
 construction is stable across instances and releases.
+
+#### Errors
+
+`KeyLengthError`, `AlphabetError`, and `DomainError` all derive from
+`FFXError` and from `ValueError`, so `except FFXError` catches every
+validation failure. Arguments of the wrong type (a non-bytes key or tweak,
+a non-str message, a non-int radix, domain, or value) raise `TypeError`.
 
 ## Security notes
 
@@ -100,19 +114,46 @@ construction is stable across instances and releases.
 
 ## Migrating from v1 (FFX[radix])
 
-v1 implemented the FFX[radix] addendum profile, which is FF1 with the tweak
-taken as a numeral string instead of raw bytes. **FF1 with the old tweak
-string encoded as ASCII bytes reproduces v1 FFX[radix] ciphertexts
-exactly** (v1 rendered radix-36 strings in lowercase):
+v2 is a rewrite with a new API. v1 implemented the FFX[radix] addendum
+profile, which is FF1 with the tweak taken as a numeral string instead of
+raw bytes. **FF1 with the old tweak string encoded as ASCII bytes reproduces
+v1 FFX[radix] ciphertexts exactly**, with the zero-tweak exception below.
+`tests/test_legacy_compat.py` verifies every vector in
+[aes-ffx-vectors.txt](aes-ffx-vectors.txt) against the new API.
 
 ```python
 # v1 encrypted "0123456789" under the tweak string "9876543210"; in v2:
 FF1(key, radix=10).encrypt("0123456789", tweak=b"9876543210")  # '6124200773'
 ```
 
-The v1 wrapper classes and factory function are gone, along with the
-big-integer dependency. `tests/test_legacy_compat.py` verifies every vector in
-[aes-ffx-vectors.txt](aes-ffx-vectors.txt) against the new API.
+Behaviour changes to check before decrypting v1 data with v2:
+
+- **Zero-valued tweaks.** v1 treated any tweak whose numeric value was zero
+  (`"0"`, `"0000000000"`, the integer `0`, ...) as *no tweak*. Decrypt such
+  records with `tweak=b""` (the default), not with the zero string encoded
+  as bytes.
+- **Case.** v1 accepted uppercase input for radix > 10 and rendered output in
+  lowercase. v2 is case-exact and its radix-N alphabets are lowercase, so
+  lowercase v1 ciphertexts before passing them to v2.
+- **Minimum length.** v1 enforced no minimum. v2 requires `n >= 2` and
+  `radix**n >= 1_000_000` by default. Data with `100 <= radix**n < 1_000_000`
+  needs `allow_small_domain=True`; data with `radix**n < 100` (including
+  every one-numeral message) cannot be decrypted by v2 at all and must be
+  re-encrypted in a larger format with v1 before upgrading.
+- **Python 3.9** is no longer supported.
+
+API changes:
+
+| v1 | v2 |
+| --- | --- |
+| `ffx.new(key, radix)`, `FFXEncrypter` | `FF1(key, radix=...)` |
+| `enc.encrypt(tweak, FFXInteger)` / `enc.decrypt(tweak, FFXInteger)` | `cipher.encrypt(str, tweak=bytes)` / `cipher.decrypt(str, tweak=bytes)` |
+| `FFXInteger` | plain `str` for numeral strings; `int` with `encrypt_int` / `decrypt_int` |
+| `FFXException` | `FFXError` |
+| `InvalidRadixException` | `AlphabetError` |
+| `UnknownTypeException` | `TypeError` |
+| `long_to_bytes`, `bytes_to_long` | removed; use `int.to_bytes` / `int.from_bytes` |
+| `pycryptodome` dependency | `cryptography` |
 
 ## Testing and benchmarks
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -37,10 +37,18 @@ x = cipher.decrypt_int(y, domain=10**9)
 - `FF1(key, *, radix=None, alphabet=None, allow_small_domain=False)`:
   key must be 16/24/32 bytes; pass `radix` (2-36) or an explicit `alphabet`
   (2-65536 unique Unicode characters), or neither for integer-only use.
-- `encrypt(s, *, tweak=b"")` / `decrypt(s, *, tweak=b"")`: same-length
-  numeral strings over the same alphabet; tweaks are arbitrary bytes.
-- `encrypt_int(x, *, domain, tweak=b"")` / `decrypt_int(y, *, domain, tweak=b"")`
- : permute integers in `[0, domain)`; independent of the instance alphabet.
+  `allow_small_domain=True` lowers the minimum domain from 1,000,000 to 100.
+  Instances are safe to share between threads.
+- `encrypt(plaintext, *, tweak=b"")` / `decrypt(ciphertext, *, tweak=b"")`:
+  same-length numeral strings over the same alphabet; input is case- and
+  character-exact; the length `n` must satisfy `n >= 2` and
+  `radix**n >= 1_000_000` (or `>= 100`); tweaks are arbitrary bytes shorter
+  than 2**32.
+- `encrypt_int(x, *, domain, tweak=b"")` / `decrypt_int(y, *, domain, tweak=b"")`:
+  permute integers in `[0, domain)` with `domain >= 1_000_000` (or `>= 100`);
+  independent of the instance alphabet and stable across releases.
+- Errors: `KeyLengthError`, `AlphabetError`, and `DomainError` derive from
+  `FFXError` and `ValueError`; wrong argument types raise `TypeError`.
 
 ## Security notes
 
@@ -56,9 +64,16 @@ x = cipher.decrypt_int(y, domain=10**9)
 
 v1 implemented the FFX[radix] addendum profile, which is FF1 with a numeral
 string tweak. FF1 with the old tweak string encoded as ASCII bytes
-reproduces v1 FFX[radix] ciphertexts exactly (v1 rendered radix-36 strings
-in lowercase). The v1 wrapper classes, factory function, and big-integer
-dependency are gone.
+reproduces v1 FFX[radix] ciphertexts exactly, except that v1 treated any
+tweak whose numeric value was zero (`"0"`, `"0000000000"`, ...) as *no
+tweak*: decrypt those records with `tweak=b""`. v1 also accepted uppercase
+input for radix > 10 (lowercase it first) and had no minimum message length
+(v2 needs `radix**n >= 1_000_000`, or `>= 100` with
+`allow_small_domain=True`; shorter v1 data cannot be decrypted by v2).
+`ffx.new` / `FFXEncrypter` / `FFXInteger` became `FF1` with `str` and `int`
+arguments, `FFXException` / `InvalidRadixException` became `FFXError` /
+`AlphabetError`, and the AES backend is now `cryptography`. The GitHub
+README has the full migration table.
 
 ## Links
 

--- a/examples/zip_code.py
+++ b/examples/zip_code.py
@@ -8,11 +8,20 @@ Encrypts postal codes while preserving:
 
 Separators (spaces, dashes) stay in place; alphanumeric characters are
 encrypted as one block per code.
+
+The cipher (radix 10 or radix 36) is chosen from the code's *format*, and
+the caller must supply the same format when decrypting. Never infer the
+format from the ciphertext: a radix-36 ciphertext of a six-character code
+is all digits about once in every two thousand codes, and decrypting it
+with the radix-10 cipher would silently return the wrong plaintext.
 """
 
 from ffx import FF1
 
 KEY = bytes.fromhex("2b7e151628aed2a6abf7158809cf4f3c")
+
+#: Postal code formats and the radix each one is encrypted in.
+FORMATS = {"digits": 10, "alnum": 36}
 
 
 def _transform(code: str, cipher: FF1, *, encrypt: bool) -> str:
@@ -22,41 +31,39 @@ def _transform(code: str, cipher: FF1, *, encrypt: bool) -> str:
     return "".join(next(new_chars) if c.isalnum() else c for c in code)
 
 
-def encrypt_postal_code(code: str, digit_cipher: FF1, alnum_cipher: FF1) -> str:
-    """Encrypt a postal code, choosing the numeric or alphanumeric cipher."""
-    chars = "".join(c for c in code if c.isalnum())
-    cipher = digit_cipher if chars.isdigit() else alnum_cipher
-    return _transform(code.lower(), cipher, encrypt=True)
+def encrypt_postal_code(code: str, fmt: str, ciphers: dict[str, FF1]) -> str:
+    """Encrypt a postal code of format ``fmt`` ("digits" or "alnum")."""
+    return _transform(code.lower(), ciphers[fmt], encrypt=True)
 
 
-def decrypt_postal_code(code: str, digit_cipher: FF1, alnum_cipher: FF1) -> str:
-    """Decrypt a postal code."""
-    chars = "".join(c for c in code if c.isalnum())
-    cipher = digit_cipher if chars.isdigit() else alnum_cipher
-    return _transform(code, cipher, encrypt=False)
+def decrypt_postal_code(code: str, fmt: str, ciphers: dict[str, FF1]) -> str:
+    """Decrypt a postal code; ``fmt`` must be the format it was encrypted with."""
+    return _transform(code, ciphers[fmt], encrypt=False)
 
 
 def main():
     # 5-digit ZIPs have a domain of 10**5, below the default minimum of
     # 10**6, so opt into the original SP 800-38G floor.
-    digit_cipher = FF1(KEY, radix=10, allow_small_domain=True)
-    alnum_cipher = FF1(KEY, radix=36, allow_small_domain=True)
+    ciphers = {
+        fmt: FF1(KEY, radix=radix, allow_small_domain=True)
+        for fmt, radix in FORMATS.items()
+    }
 
     codes = [
-        "90210",        # US 5-digit ZIP
-        "10001-4356",   # US ZIP+4
-        "K1A 0B1",      # Canadian postal code
-        "SW1A 1AA",     # UK postcode
+        ("90210", "digits"),       # US 5-digit ZIP
+        ("10001-4356", "digits"),  # US ZIP+4
+        ("K1A 0B1", "alnum"),      # Canadian postal code
+        ("SW1A 1AA", "alnum"),     # UK postcode
     ]
 
     print("Postal Code Format-Preserving Encryption")
     print("=" * 50)
 
-    for code in codes:
-        encrypted = encrypt_postal_code(code, digit_cipher, alnum_cipher)
-        decrypted = decrypt_postal_code(encrypted, digit_cipher, alnum_cipher)
+    for code, fmt in codes:
+        encrypted = encrypt_postal_code(code, fmt, ciphers)
+        decrypted = decrypt_postal_code(encrypted, fmt, ciphers)
 
-        print(f"\nOriginal:  {code}")
+        print(f"\nOriginal:  {code}  ({fmt})")
         print(f"Encrypted: {encrypted}")
         print(f"Decrypted: {decrypted}")
         print(f"Verified:  {'ok' if code.lower() == decrypted else 'MISMATCH'}")

--- a/ffx/exceptions.py
+++ b/ffx/exceptions.py
@@ -1,8 +1,18 @@
-"""Exception hierarchy for the ffx package."""
+"""Exception hierarchy for the ffx package.
+
+Every validation error raised by the package derives from :class:`FFXError`
+and from :class:`ValueError`. Arguments of the wrong *type* (a non-bytes key
+or tweak, a non-str message, a non-int radix, domain, or value) raise
+:class:`TypeError` instead, following the usual Python convention.
+"""
 
 
 class FFXError(Exception):
-    """Base class for all errors raised by the ffx package."""
+    """Base class for the validation errors raised by the ffx package:
+    :class:`KeyLengthError`, :class:`AlphabetError`, :class:`DomainError`.
+
+    Arguments of the wrong type raise :class:`TypeError`, not an
+    ``FFXError``."""
 
 
 class KeyLengthError(FFXError, ValueError):
@@ -15,5 +25,6 @@ class AlphabetError(FFXError, ValueError):
 
 
 class DomainError(FFXError, ValueError):
-    """Raised when a message or integer falls outside the permitted domain
-    (too short, domain below the minimum, or value out of range)."""
+    """Raised when a message, integer, or tweak falls outside the permitted
+    domain (message too short, domain below the minimum, value out of
+    range, or tweak of 2**32 bytes or more)."""

--- a/ffx/ff1.py
+++ b/ffx/ff1.py
@@ -41,6 +41,15 @@ _MAX_ALPHABET = 65536
 
 _MAX_TWEAK_BYTES = 2 ** 32  # exclusive: len(tweak) must be < 2**32
 
+#: Largest number of AES blocks handed to the shared ECB context in one
+#: update() call. cryptography releases the GIL while encrypting a buffer
+#: of 2048 bytes or more, and its CipherContext stays exclusively borrowed
+#: until the call returns, so a second thread using the same context in
+#: that window fails with RuntimeError("Already borrowed"). Keeping every
+#: call below the threshold is what makes one FF1 instance safe to share
+#: between threads; ECB blocks are independent, so splitting is exact.
+_ECB_MAX_BLOCKS_PER_CALL = 127  # 127 * 16 = 2032 bytes
+
 
 class _FParams(NamedTuple):
     """Cached, (radix, n, t)-dependent parameters for the round function.
@@ -59,6 +68,42 @@ class _FParams(NamedTuple):
     mod_odd: int      # radix ** v, the modulus on odd rounds
 
 
+class _Numerals(NamedTuple):
+    """The numeral alphabet of a string-API instance, with the
+    SP 800-38G NUM/STR conversions over it. Integer-only instances
+    (no radix/alphabet) have none."""
+
+    alphabet: str
+    radix: int
+    char_to_digit: dict[str, int]
+
+    def to_int(self, s: str) -> int:
+        """NUM_radix(s): fold a numeral string to an integer."""
+        radix = self.radix
+        lookup = self.char_to_digit
+        x = 0
+        try:
+            for ch in s:
+                x = x * radix + lookup[ch]
+        except KeyError:
+            bad = next(ch for ch in s if ch not in lookup)
+            raise AlphabetError(
+                f"character {bad!r} is not in the alphabet"
+            ) from None
+        return x
+
+    def to_str(self, x: int, width: int) -> str:
+        """STR_radix(x, width): unfold an integer to a fixed-width numeral
+        string."""
+        radix = self.radix
+        alphabet = self.alphabet
+        out: list[str] = []
+        for _ in range(width):
+            x, digit = divmod(x, radix)
+            out.append(alphabet[digit])
+        return "".join(reversed(out))
+
+
 class FF1:
     """NIST SP 800-38G FF1 format-preserving encryption.
 
@@ -71,6 +116,8 @@ class FF1:
             given; with neither, only ``encrypt_int``/``decrypt_int`` work.
         allow_small_domain: Relax the minimum domain size from 1,000,000
             (Draft SP 800-38G Rev 1) to 100 (original SP 800-38G).
+
+    Instances keep no per-call state and may be shared between threads.
 
     Example:
         >>> cipher = FF1(bytes.fromhex("2b7e151628aed2a6abf7158809cf4f3c"),
@@ -109,7 +156,7 @@ class FF1:
             raise AlphabetError("pass at most one of radix= and alphabet=")
         if radix is not None:
             if not isinstance(radix, int) or isinstance(radix, bool):
-                raise AlphabetError(
+                raise TypeError(
                     f"radix must be an int, got {type(radix).__name__}"
                 )
             if not 2 <= radix <= 36:
@@ -117,7 +164,7 @@ class FF1:
             alphabet = _BASE36_ALPHABET[:radix]
         elif alphabet is not None:
             if not isinstance(alphabet, str):
-                raise AlphabetError(
+                raise TypeError(
                     f"alphabet must be a str, got {type(alphabet).__name__}"
                 )
             if len(alphabet) < 2:
@@ -131,10 +178,10 @@ class FF1:
             if len(set(alphabet)) != len(alphabet):
                 raise AlphabetError("alphabet characters must be unique")
 
-        self._alphabet = alphabet
-        self._radix = len(alphabet) if alphabet is not None else None
-        self._char_to_digit = (
-            {c: i for i, c in enumerate(alphabet)} if alphabet is not None else None
+        self._numerals = (
+            _Numerals(alphabet, len(alphabet), {c: i for i, c in enumerate(alphabet)})
+            if alphabet is not None
+            else None
         )
         self._allow_small_domain = bool(allow_small_domain)
         self._min_domain = (
@@ -174,7 +221,8 @@ class FF1:
 
     def _crypt_str(self, message: str, tweak: bytes, *, encrypt: bool) -> str:
         tweak = self._check_tweak(tweak)
-        if self._alphabet is None:
+        numerals = self._numerals
+        if numerals is None:
             raise AlphabetError(
                 "this FF1 instance was built without a numeral alphabet; "
                 "pass radix= or alphabet= to FF1() to work with strings"
@@ -184,7 +232,7 @@ class FF1:
                 f"message must be a str, got {type(message).__name__}"
             )
 
-        radix = self._radix
+        radix = numerals.radix
         n = len(message)
         if n < 2 or radix ** n < self._min_domain:
             raise DomainError(
@@ -194,13 +242,13 @@ class FF1:
             )
 
         u = n // 2
-        a = self._str_to_int(message[:u])
-        b = self._str_to_int(message[u:])
+        a = numerals.to_int(message[:u])
+        b = numerals.to_int(message[u:])
         if encrypt:
             a, b = self._encrypt_core(radix, n, a, b, tweak)
         else:
             a, b = self._decrypt_core(radix, n, a, b, tweak)
-        return self._int_to_str(a, u) + self._int_to_str(b, n - u)
+        return numerals.to_str(a, u) + numerals.to_str(b, n - u)
 
     # ------------------------------------------------------------------
     # Integer API (normative wire contract; see module docstring)
@@ -253,7 +301,7 @@ class FF1:
         return (domain - 1).bit_length()
 
     # ------------------------------------------------------------------
-    # Shared validation and numeral conversion
+    # Shared validation
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -263,35 +311,8 @@ class FF1:
                 f"tweak must be bytes, got {type(tweak).__name__}"
             )
         if len(tweak) >= _MAX_TWEAK_BYTES:
-            raise ValueError("tweak must be shorter than 2**32 bytes")
+            raise DomainError("tweak must be shorter than 2**32 bytes")
         return bytes(tweak)
-
-    def _str_to_int(self, s: str) -> int:
-        """NUM_radix(s): fold a numeral string to an integer via the
-        instance alphabet."""
-        radix = self._radix
-        lookup = self._char_to_digit
-        x = 0
-        try:
-            for ch in s:
-                x = x * radix + lookup[ch]
-        except KeyError:
-            bad = next(ch for ch in s if ch not in lookup)
-            raise AlphabetError(
-                f"character {bad!r} is not in the alphabet"
-            ) from None
-        return x
-
-    def _int_to_str(self, x: int, width: int) -> str:
-        """STR_radix(x, width): unfold an integer to a fixed-width numeral
-        string via the instance alphabet."""
-        radix = self._radix
-        alphabet = self._alphabet
-        out = []
-        for _ in range(width):
-            x, digit = divmod(x, radix)
-            out.append(alphabet[digit])
-        return "".join(reversed(out))
 
     # ------------------------------------------------------------------
     # FF1 core (SP 800-38G Algorithms 7 and 8)
@@ -361,15 +382,20 @@ class FF1:
 
         # S = first d bytes of R || AES(R xor [1]) || AES(R xor [2]) || ...
         # The extension blocks are mutually independent, so they are
-        # concatenated and encrypted in a single ECB call.
+        # concatenated and encrypted in as few ECB calls as the per-call
+        # size limit allows (a single call for any right half up to 2032
+        # bytes, i.e. every practical message).
         d = params.d
         if d <= 16:
             return r_int >> (8 * (16 - d))
         extra_blocks = -(-(d - 16) // 16)
-        buf = b"".join(
-            (r_int ^ j).to_bytes(16, "big") for j in range(1, extra_blocks + 1)
-        )
-        S = r_int.to_bytes(16, "big") + ecb_encrypt(buf)
+        parts = [r_int.to_bytes(16, "big")]
+        for start in range(1, extra_blocks + 1, _ECB_MAX_BLOCKS_PER_CALL):
+            stop = min(start + _ECB_MAX_BLOCKS_PER_CALL, extra_blocks + 1)
+            parts.append(ecb_encrypt(b"".join(
+                (r_int ^ j).to_bytes(16, "big") for j in range(start, stop)
+            )))
+        S = b"".join(parts)
         return int.from_bytes(S[:d], "big")
 
     def _encrypt_core(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "libffx"
 version = "2.0.0"
 description = "FF1 format-preserving encryption (NIST SP 800-38G)"
 readme = "README_PYPI.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Kevin P. Dyer", email = "kpdyer@gmail.com"}
 ]
@@ -18,7 +19,6 @@ keywords = ["cryptography", "encryption", "format-preserving", "ff1", "ffx", "fp
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/test_legacy_compat.py
+++ b/tests/test_legacy_compat.py
@@ -72,3 +72,27 @@ def test_legacy_decrypt(radix, tweak, plaintext, ciphertext):
     cipher = FF1(KEY, radix=radix)
     got = cipher.decrypt(normalize(ciphertext, radix), tweak=tweak)
     assert got == normalize(plaintext, radix)
+
+
+def test_v1_zero_valued_tweak_means_no_tweak():
+    """v1 treated any tweak whose numeric value was 0 as *no* tweak.
+
+    The v1 README's own radix-2 example (all-zero key, tweak "0" * 8,
+    plaintext "0" * 8) printed ciphertext "10100010"; FF1 reproduces it
+    only with an empty tweak, not with the zero string encoded as bytes.
+    """
+    cipher = FF1(bytes(16), radix=2, allow_small_domain=True)
+    assert cipher.encrypt("00000000") == "10100010"
+    assert cipher.encrypt("00000000", tweak=b"00000000") != "10100010"
+
+
+def test_v1_zero_valued_tweak_radix10():
+    """Vectors generated with libffx 1.0.3 (radix 10, the NIST AES-128 key):
+    the tweak strings "0000000000" and "0", and the integer tweak 0, all gave
+    "3662311239797070" for "4111111111111111", i.e. the no-tweak ciphertext;
+    the non-zero tweak string "0000000001" gave "9027324768307529", which its
+    ASCII encoding reproduces."""
+    cipher = FF1(bytes.fromhex("2b7e151628aed2a6abf7158809cf4f3c"), radix=10)
+    assert cipher.encrypt("4111111111111111") == "3662311239797070"
+    assert cipher.encrypt("4111111111111111", tweak=b"0000000000") != "3662311239797070"
+    assert cipher.encrypt("4111111111111111", tweak=b"0000000001") == "9027324768307529"

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,86 @@
+"""One FF1 instance shared between threads.
+
+FF1 keeps no per-call state, but every call goes through one persistent
+AES-ECB context from ``cryptography``. That backend releases the GIL while
+encrypting a buffer of 2048 bytes or more and holds an exclusive borrow on
+the context until the call returns, so a second thread using the same
+context in that window fails with ``RuntimeError: Already borrowed``. The
+library therefore never hands the shared context a buffer that large; the
+only place that could is the S-extension step for wide right halves, which
+is split into calls of at most 127 blocks (2032 bytes).
+"""
+
+import random
+import threading
+
+from ffx import FF1
+
+KEY = bytes(range(16))
+BIG_ALPHABET = "".join(map(chr, range(65536)))
+
+
+def run_in_threads(work, n_threads=8):
+    errors = []
+
+    def worker():
+        try:
+            work()
+        except BaseException as exc:  # noqa: BLE001 - surface everything
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, errors[0]
+
+
+def test_ecb_calls_stay_below_gil_release_threshold():
+    """Deterministic form of the invariant: record every buffer handed to
+    the shared ECB context while encrypting a message whose S-extension
+    would otherwise be a single 4400-byte call, and check none reaches
+    2048 bytes."""
+    cipher = FF1(KEY, alphabet=BIG_ALPHABET)
+    sizes = []
+    real_ecb_encrypt = cipher._ecb_encrypt
+
+    def recording_ecb_encrypt(buf):
+        sizes.append(len(buf))
+        return real_ecb_encrypt(buf)
+
+    cipher._ecb_encrypt = recording_ecb_encrypt
+    rng = random.Random(4400)
+    plaintext = "".join(rng.choices(BIG_ALPHABET, k=4400))  # d = 4404
+    assert cipher.decrypt(cipher.encrypt(plaintext)) == plaintext
+    assert max(sizes) >= 1024, "the S-extension path was not exercised"
+    assert max(sizes) < 2048
+
+
+def test_shared_instance_short_messages():
+    cipher = FF1(KEY, radix=10)
+    plaintext = "4111111111111111"
+    expected = cipher.encrypt(plaintext, tweak=b"t")
+
+    def work():
+        for _ in range(500):
+            assert cipher.encrypt(plaintext, tweak=b"t") == expected
+            assert cipher.decrypt(expected, tweak=b"t") == plaintext
+
+    run_in_threads(work)
+
+
+def test_shared_instance_long_messages():
+    # radix 65536, n = 2200: d = 2204, so each round's S-extension covers
+    # 137 blocks and takes the chunked path.
+    cipher = FF1(KEY, alphabet=BIG_ALPHABET)
+    rng = random.Random(2200)
+    plaintext = "".join(rng.choices(BIG_ALPHABET, k=2200))
+    expected = cipher.encrypt(plaintext, tweak=b"long")
+
+    def work():
+        for _ in range(5):
+            assert cipher.encrypt(plaintext, tweak=b"long") == expected
+            assert cipher.decrypt(expected, tweak=b"long") == plaintext
+
+    run_in_threads(work)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -111,3 +111,35 @@ class TestTweaks:
         assert cipher.encrypt("123456", tweak=bytearray(b"tw")) == cipher.encrypt(
             "123456", tweak=b"tw"
         )
+
+    def test_tweak_too_long_is_domain_error(self):
+        class Huge(bytes):
+            def __len__(self):
+                return 2**32
+
+        cipher = FF1(KEY, radix=10)
+        with pytest.raises(DomainError):
+            cipher.encrypt("123456", tweak=Huge())
+        with pytest.raises(DomainError):
+            cipher.encrypt_int(0, domain=10**6, tweak=Huge())
+
+
+class TestArgumentTypes:
+    """Wrong argument *types* raise TypeError, never an FFXError."""
+
+    @pytest.mark.parametrize("radix", ["10", 10.0, True, [10]])
+    def test_radix_must_be_int(self, radix):
+        with pytest.raises(TypeError):
+            FF1(KEY, radix=radix)
+
+    @pytest.mark.parametrize("alphabet", [b"0123456789", 36, ["a", "b"]])
+    def test_alphabet_must_be_str(self, alphabet):
+        with pytest.raises(TypeError):
+            FF1(KEY, alphabet=alphabet)
+
+
+class TestErrorHierarchy:
+    def test_validation_errors_are_ffxerror_and_valueerror(self):
+        for exc in (KeyLengthError, AlphabetError, DomainError):
+            assert issubclass(exc, FFXError)
+            assert issubclass(exc, ValueError)


### PR DESCRIPTION
## Summary

Fixes found in the pre-release review, all needed before publishing 2.0.0:

- **Migration docs**: v1 treated zero-valued tweaks (`"0"`, `"0000000000"`, `0`) as *no tweak*; following the old "encode as ASCII bytes" rule would decrypt those records to garbage. Also documents case-exactness, minimum lengths, dropped Python 3.9, and a full v1 -> v2 name/exception table.
- **Error types** (API-shaped, so settled before 2.0.0): oversize tweak raises `DomainError` instead of bare `ValueError`; non-int radix / non-str alphabet raise `TypeError` like other type mistakes; `FFXError` docstring now accurate.
- **Thread safety**: the S-extension step never hands the shared AES context >= 2048 bytes (where `cryptography` releases the GIL while exclusively borrowed, causing `RuntimeError: Already borrowed` from concurrent threads on very long messages). Bit-exact.
- **zip_code example**: cipher chosen from the caller-supplied format, not the ciphertext (which mis-decrypted all-digit radix-36 outputs silently).
- **Packaging**: sdist now includes the vector file and `tests/__init__.py` so `pytest` works from the tarball; SPDX license metadata.
- **mypy**: 8 Optional-narrowing errors fixed via a typed `_Numerals` helper; `mypy ffx` added to CI.

## Test plan

- [x] `pytest`: 107 passed (locally on 3.14)
- [x] `pytest` from inside the built sdist: 107 passed
- [x] `mypy ffx`: clean
- [x] `example.py`, all 11 `examples/*.py`, `benchmark.py` run
- [x] NIST and legacy vectors unchanged; v1 zero-tweak vectors regenerated with libffx 1.0.3
- [ ] CI matrix 3.10-3.14 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
