### PR TITLE
Restructure README_PYPI.md for readable rendering on PyPI; release 2.0.1

### DIFF
--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -1,15 +1,24 @@
 # libffx - FF1 Format-Preserving Encryption
 
 [![PyPI version](https://img.shields.io/pypi/v/libffx.svg)](https://pypi.org/project/libffx/)
+[![Tests](https://github.com/kpdyer/libffx/actions/workflows/tests.yml/badge.svg)](https://github.com/kpdyer/libffx/actions/workflows/tests.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A pure-Python implementation of **NIST SP 800-38G FF1** format-preserving
-encryption (FPE), with AES-128/192/256. The only dependency is
-`cryptography` (OpenSSL-backed AES).
+encryption (FPE), with AES-128/192/256.
 
 Format-preserving encryption encrypts data while preserving its format: a
-16-digit credit card number encrypts to another 16-digit number.
+16-digit credit card number encrypts to another 16-digit number, and a DNA
+string over `ACGT` encrypts to another DNA string of the same length.
+
+## Installation
+
+```bash
+pip install libffx
+```
+
+The only dependency is `cryptography` (OpenSSL-backed AES). Python 3.10+.
 
 ## Quick Start
 
@@ -23,63 +32,133 @@ cipher = FF1(key, radix=10)
 ciphertext = cipher.encrypt("4111111111111111", tweak=b"account-42")
 plaintext = cipher.decrypt(ciphertext, tweak=b"account-42")
 
-# Custom alphabets
+# Custom alphabets (any unique Unicode characters, up to 65536)
 dna = FF1(key, alphabet="ACGT")
 encrypted = dna.encrypt("ACGTACGTACGT")
 
 # Integers in an arbitrary domain [0, N)
-y = cipher.encrypt_int(123456789, domain=10**9)
-x = cipher.decrypt_int(y, domain=10**9)
+plain = FF1(key)  # no alphabet needed for the integer API
+y = plain.encrypt_int(123456789, domain=10**9)
+x = plain.decrypt_int(y, domain=10**9)
 ```
 
 ## API
 
-- `FF1(key, *, radix=None, alphabet=None, allow_small_domain=False)`:
-  key must be 16/24/32 bytes; pass `radix` (2-36) or an explicit `alphabet`
-  (2-65536 unique Unicode characters), or neither for integer-only use.
-  `allow_small_domain=True` lowers the minimum domain from 1,000,000 to 100.
-  Instances are safe to share between threads.
-- `encrypt(plaintext, *, tweak=b"")` / `decrypt(ciphertext, *, tweak=b"")`:
-  same-length numeral strings over the same alphabet; input is case- and
-  character-exact; the length `n` must satisfy `n >= 2` and
-  `radix**n >= 1_000_000` (or `>= 100`); tweaks are arbitrary bytes shorter
-  than 2**32.
-- `encrypt_int(x, *, domain, tweak=b"")` / `decrypt_int(y, *, domain, tweak=b"")`:
-  permute integers in `[0, domain)` with `domain >= 1_000_000` (or `>= 100`);
-  independent of the instance alphabet and stable across releases.
-- Errors: `KeyLengthError`, `AlphabetError`, and `DomainError` derive from
-  `FFXError` and `ValueError`; wrong argument types raise `TypeError`.
+### `FF1`
+
+```python
+FF1(key, *, radix=None, alphabet=None, allow_small_domain=False)
+```
+
+- `key`: `bytes` (or `bytearray`) of exactly 16, 24, or 32 bytes
+  (AES-128/192/256); other lengths raise `KeyLengthError`.
+- `radix`: 2-36; the alphabet is `"0123456789abcdefghijklmnopqrstuvwxyz"[:radix]`.
+- `alphabet`: explicit alphabet string (2-65536 unique Unicode characters).
+  At most one of `radix`/`alphabet` may be given. With neither, only the
+  integer API is available.
+- `allow_small_domain`: relax the minimum domain from 1,000,000 (Draft
+  SP 800-38G Rev 1) to 100 (original SP 800-38G).
+
+Instances hold no per-call state and are safe to share between threads;
+construct one per key and reuse it.
+
+### `encrypt` / `decrypt`
+
+```python
+encrypt(plaintext, *, tweak=b"") -> str
+decrypt(ciphertext, *, tweak=b"") -> str
+```
+
+Encrypt or decrypt a numeral string. Output has the same length over the
+same alphabet. Input is case- and character-exact (no normalization);
+characters outside the alphabet raise `AlphabetError`. The message length
+`n` must satisfy `n >= 2` and `radix**n >= 1_000_000` (or `>= 100` with
+`allow_small_domain=True`); otherwise `DomainError`.
+
+Tweaks are arbitrary bytes (`len < 2**32`, else `DomainError`) acting as
+public associated data: the same plaintext under different tweaks yields
+unrelated ciphertexts.
+
+### `encrypt_int` / `decrypt_int`
+
+```python
+encrypt_int(x, *, domain, tweak=b"") -> int
+decrypt_int(y, *, domain, tweak=b"") -> int
+```
+
+Encrypt an integer `0 <= x < domain` to another integer in the same range.
+`domain` must be at least 1,000,000 (100 with `allow_small_domain=True`);
+a smaller domain or an out-of-range value raises `DomainError`. Results
+depend only on (key, domain, tweak), not on the instance's
+`radix`/`alphabet`, so the construction is stable across instances and
+releases.
+
+### Errors
+
+`KeyLengthError`, `AlphabetError`, and `DomainError` all derive from
+`FFXError` and from `ValueError`, so `except FFXError` catches every
+validation failure. Arguments of the wrong type (a non-bytes key or tweak,
+a non-str message, a non-int radix, domain, or value) raise `TypeError`.
 
 ## Security notes
 
-- FF1 is **deterministic**: equal plaintexts under the same key and tweak
-  give equal ciphertexts. Use tweaks as public associated data to separate
-  records.
-- Message domains must satisfy `radix**n >= 1_000_000` (Draft SP 800-38G
-  Rev 1). `allow_small_domain=True` relaxes the floor to 100 (original
-  SP 800-38G); small domains are fundamentally weaker.
-- Always use cryptographically random keys.
+- **Deterministic**: FF1 is a deterministic permutation. Equal plaintexts
+  under the same key and tweak produce equal ciphertexts. Use tweaks
+  (e.g. a record identifier) to prevent cross-record equality leakage.
+- **Domain minimums**: small domains are fundamentally weak for FPE. The
+  default floor of 1,000,000 follows Draft SP 800-38G Rev 1;
+  `allow_small_domain=True` opts into the original floor of 100; use it
+  only when you understand the risk.
+- Always use cryptographically random keys (e.g. `secrets.token_bytes(16)`).
 
 ## Migrating from v1
 
-v1 implemented the FFX[radix] addendum profile, which is FF1 with a numeral
-string tweak. FF1 with the old tweak string encoded as ASCII bytes
-reproduces v1 FFX[radix] ciphertexts exactly, except that v1 treated any
-tweak whose numeric value was zero (`"0"`, `"0000000000"`, ...) as *no
-tweak*: decrypt those records with `tweak=b""`. v1 also accepted uppercase
-input for radix > 10 (lowercase it first) and had no minimum message length
-(v2 needs `radix**n >= 1_000_000`, or `>= 100` with
-`allow_small_domain=True`; shorter v1 data cannot be decrypted by v2).
-`ffx.new` / `FFXEncrypter` / `FFXInteger` became `FF1` with `str` and `int`
-arguments, `FFXException` / `InvalidRadixException` became `FFXError` /
-`AlphabetError`, and the AES backend is now `cryptography`. The GitHub
-README has the full migration table.
+v2 is a rewrite with a new API. v1 implemented the FFX[radix] addendum
+profile, which is FF1 with the tweak taken as a numeral string instead of
+raw bytes. **FF1 with the old tweak string encoded as ASCII bytes reproduces
+v1 FFX[radix] ciphertexts exactly**, with the zero-tweak exception below.
+
+```python
+# v1 encrypted "0123456789" under the tweak string "9876543210"; in v2:
+FF1(key, radix=10).encrypt("0123456789", tweak=b"9876543210")  # '6124200773'
+```
+
+Behaviour changes to check before decrypting v1 data with v2:
+
+- **Zero-valued tweaks.** v1 treated any tweak whose numeric value was zero
+  (`"0"`, `"0000000000"`, the integer `0`, ...) as *no tweak*. Decrypt such
+  records with `tweak=b""` (the default), not with the zero string encoded
+  as bytes.
+- **Case.** v1 accepted uppercase input for radix > 10 and rendered output in
+  lowercase. v2 is case-exact and its radix-N alphabets are lowercase, so
+  lowercase v1 ciphertexts before passing them to v2.
+- **Minimum length.** v1 enforced no minimum. v2 requires `n >= 2` and
+  `radix**n >= 1_000_000` by default. Data with `100 <= radix**n < 1_000_000`
+  needs `allow_small_domain=True`; data with `radix**n < 100` (including
+  every one-numeral message) cannot be decrypted by v2 at all and must be
+  re-encrypted in a larger format with v1 before upgrading.
+- **Python 3.9** is no longer supported.
+
+API changes:
+
+| v1 | v2 |
+| --- | --- |
+| `ffx.new(key, radix)`, `FFXEncrypter` | `FF1(key, radix=...)` |
+| `enc.encrypt(tweak, FFXInteger)` / `enc.decrypt(tweak, FFXInteger)` | `cipher.encrypt(str, tweak=bytes)` / `cipher.decrypt(str, tweak=bytes)` |
+| `FFXInteger` | plain `str` for numeral strings; `int` with `encrypt_int` / `decrypt_int` |
+| `FFXException` | `FFXError` |
+| `InvalidRadixException` | `AlphabetError` |
+| `UnknownTypeException` | `TypeError` |
+| `long_to_bytes`, `bytes_to_long` | removed; use `int.to_bytes` / `int.from_bytes` |
+| `pycryptodome` dependency | `cryptography` |
 
 ## Links
 
-- [GitHub Repository](https://github.com/kpdyer/libffx)
-- [Issue Tracker](https://github.com/kpdyer/libffx/issues)
+- [Source, issues, and full README](https://github.com/kpdyer/libffx)
 - [NIST SP 800-38G](https://csrc.nist.gov/publications/detail/sp/800-38g/final)
+- [Test vectors](https://github.com/kpdyer/libffx/tree/master/tests): the
+  official NIST FF1 samples and the legacy Voltage Security FFX[radix]
+  vectors, both verified by the test suite
 
 ## License
 

--- a/ffx/__init__.py
+++ b/ffx/__init__.py
@@ -33,4 +33,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libffx"
-version = "2.0.0"
+version = "2.0.1"
 description = "FF1 format-preserving encryption (NIST SP 800-38G)"
 readme = "README_PYPI.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

The 2.0.0 description on https://pypi.org/project/libffx/ renders as valid markdown but reads poorly: the API section is four dense bullets with long inline signatures, and the v1 migration guide is a single paragraph.

This brings `README_PYPI.md` in line with the GitHub README's layout:

- **API**: per-function headings (`FF1`, `encrypt` / `decrypt`, `encrypt_int` / `decrypt_int`, `Errors`) with the signature in a highlighted code block, then short bullets.
- **Installation** section with the `pip install` block.
- **Migrating from v1**: the worked example, bulleted behaviour caveats (zero tweaks, case, minimum length, Python 3.9), and the v1 -> v2 API table. PyPI's `readme_renderer` supports GFM tables.
- Absolute links only (relative links break on PyPI); adds the Tests badge.

PyPI descriptions are immutable per release, so this bumps the version to **2.0.1** (same precedent as v1.0.1, "Cleaner PyPI README"). No code changes.

## Test plan

- [x] Rendered old and new `README_PYPI.md` through `readme_renderer.markdown` (the renderer PyPI uses) and compared screenshots: 6 code blocks and 1 table in the new version, no rendering errors
- [x] `python -m build` + `twine check --strict`: PASSED for wheel and sdist
- [x] `pytest`: 107 passed; `ffx.__version__ == "2.0.1"`
- [ ] CI matrix 3.10-3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
