### PR TITLE
Remove packaging bits made redundant by pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Python dependencies (pyproject.toml + requirements.txt)
+  # Python dependencies (pyproject.toml)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
-include LICENSE
 include README.md
-include README_PYPI.md
 include SECURITY.md
 include aes-ffx-vectors.txt
 include example.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=84.0.0", "wheel"]
+requires = ["setuptools>=84.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-cryptography>=42.0.0


### PR DESCRIPTION
## Summary

Cleans up dependency/packaging metadata that duplicated what `pyproject.toml` already declares.

- **Remove `requirements.txt`.** It held the single runtime dep already in `pyproject.toml`. Nothing consumed it: CI installs with `pip install -e ".[dev]"`, and Dependabot already edits `pyproject.toml` directly (see #41).
- **Drop `wheel` from `[build-system] requires`.** setuptools has built wheels without it since 70.1; we require >=84.
- **Drop `LICENSE` and `README_PYPI.md` from `MANIFEST.in`.** `license-files` and `readme` in `pyproject.toml` already put both into the sdist and wheel.
- **Fix the Dependabot config comment** that still mentioned `requirements.txt`.

`MANIFEST.in` itself stays: setuptools has no `pyproject.toml` equivalent for shipping `tests/`, `examples/`, and `aes-ffx-vectors.txt` in the sdist, and `tests/test_legacy_compat.py` reads the vector file from the repo root.

Deliberately **not** pinning `cryptography` to an exact version: libffx is a library, and an exact pin (or even an upper cap, given cryptography's recent one-major-per-month cadence) would cause resolver conflicts for downstream users and block security fixes. Dependabot + CI already catch breaking releases.

## Verification

- `python -m build` succeeds without `wheel` in build requires.
- sdist still contains `LICENSE` and `README_PYPI.md`; wheel ships `LICENSE` under `dist-info/licenses/`.
- `pytest`: 107 passed. `mypy ffx`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
